### PR TITLE
fix elementsByCss use wrong strategy

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 2.0.12 / 2017-07-05
+
+### update wd.java fix elementsByCss using="selector" issue
+*   the using="selector" is wrong for webview mode. should be "css".
+
 # 2.0.8 / 2017-06-02
 
 ### update wd.java for macaca 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>macaca.webdriver.client</groupId>
 	<artifactId>macacaclient</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.11</version>
+	<version>2.0.12</version>
 	<name>macacaclient</name>
 	<url>http://maven.apache.org</url>
 	<build>

--- a/src/main/java/macaca/client/MacacaClient.java
+++ b/src/main/java/macaca/client/MacacaClient.java
@@ -693,7 +693,7 @@ public class MacacaClient {
 	public ElementSelector elementsByCss(String css) throws Exception {
 		JSONObject jsonObject = new JSONObject();
 		jsonObject.put("value", css);
-		jsonObject.put("using", "selector");
+		jsonObject.put("using", "css");
 		JSONArray jsonArray = findElements(jsonObject);
 		return new ElementSelector(contexts, this, jsonArray);
 	}


### PR DESCRIPTION
strategy "selector" is not supported by chromedriver.
it should be "css" for elementsByCss command.
following was the error log.

2017-07-05 15:03:03 Request:http://localhost:3456/wd/hub/session/c0519063-2513-483b-bdc1-2e4f1d166819/elements:{"using":"selector","value":"div.swiper"}
七月 05, 2017 3:03:03 下午 com.pajk.qa.command.ExecCommand run
信息: >> responseHandler.js:11:12 [master] pid:14808 Recieve HTTP Request from Client[2017-07-05 15:03:03]: method: POST url: /wd/hub/session/c0519063-2513-483b-bdc1-2e4f1d166819/elements, jsonBody: {"using":"selector","value":"div.swiper"}
七月 05, 2017 3:03:03 下午 com.pajk.qa.command.ExecCommand run
信息: >> proxy.js:52:14 [master] pid:14808 Proxy: /wd/hub/session/c0519063-2513-483b-bdc1-2e4f1d166819/elements:POST to http://localhost:9515/wd/hub/session/46564a5346e1aa454ca57cbdec2ae541/elements:POST with body: {"using":"selector","value":"div.swiper"}
七月 05, 2017 3:03:03 下午 com.pajk.qa.command.ExecCommand run
信息: >> proxy.js:58:16 [master] pid:14808 Got response with status 200: {"sessionId":"46564a5346e1aa454ca57cbdec2ae541","status":13,"value":{"message":"unknown error: Unsupported locator strategy: selector\n  (Session info: chrome=55.0.2883.91)\n  (Driver info: chromed...
七月 05, 2017 3:03:03 下午 com.pajk.qa.command.ExecCommand run
信息: >> session.js:107:14 [master] pid:14808 Send HTTP Respone to Client[2017-07-05 15:03:03]: {"sessionId":"c0519063-2513-483b-bdc1-2e4f1d166819","status":13,"value":"{\"message\":\"unknown error: Unsupported locator strategy: selector\\n  (Session info: chrome=55.0.2883.91)\\n  (Driver info: chromedriver=2.27.440174 (e97a722caafc2d3a8b807ee115bfb307f7d2cfd9),platform=Windows NT 6.1.7601 SP1 x86_64)\"}"}
2017-07-05 15:03:03 Response:{"sessionId":"c0519063-2513-483b-bdc1-2e4f1d166819","status":13,"value":{"message":"unknown error: Unsupported locator strategy: selector\n  (Session info: chrome=55.0.2883.91)\n  (Driver info: chromedriver=2.27.440174 (e97a722caafc2d3a8b807ee115bfb307f7d2cfd9),platform=Windows NT 6.1.7601 SP1 x86_64)"}}
java.lang.Exception: An unknown server-side error occurred while processing the command.
	at macaca.client.common.Utils.handleStatus(Utils.java:165)
	at macaca.client.common.Utils.postRequest(Utils.java:115)
	at macaca.client.common.Utils.request(Utils.java:154)
	at macaca.client.MacacaClient.findElements(MacacaClient.java:206)
	at macaca.client.MacacaClient.elementsByCss(MacacaClient.java:697)
	at com.pajk.qa.cases.ShoppingMall2020UI.testProductPerchaseProcdure(ShoppingMall2020UI.java:89)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:714)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:901)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1231)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:127)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:111)
	at org.testng.TestRunner.privateRun(TestRunner.java:767)
	at org.testng.TestRunner.run(TestRunner.java:617)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:343)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:305)
	at org.testng.SuiteRunner.run(SuiteRunner.java:254)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
	at org.testng.TestNG.run(TestNG.java:1057)
	at org.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:72)
	at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:124)