### PR TITLE
enhance connect pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>macaca.webdriver.client</groupId>
   <artifactId>macacaclient</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.25</version>
+  <version>2.0.26</version>
   <name>macacaclient</name>
   <url>http://maven.apache.org</url>
   <build>

--- a/src/main/java/macaca/client/common/Utils.java
+++ b/src/main/java/macaca/client/common/Utils.java
@@ -26,19 +26,20 @@ public class Utils {
 //    private final Log log = LogFactory.getLog(getClass());
 
     private HttpGet httpget = null;
-    //使用静态变量保证应用中初始化多个macacaClient实例也会使用同一个连接池
+    //Use static variables to ensure that the same connection pool is used when
+    // multiple macacaClient instances are initialized in the application.
     private static CloseableHttpClient httpclient;
     static {
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        //单个路由域名最大连接数
+        //max size conect per host route
         connectionManager.setDefaultMaxPerRoute(500);
-        //最大连接维持数
+        //max size connect
         connectionManager.setMaxTotal(1000);
         HttpClientBuilder builder = HttpClientBuilder.create();
 
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setCookieSpec(
                 CookieSpecs.STANDARD);
-        //设置超时时间
+        //set timeout config
         RequestConfig requestConfig = requestConfigBuilder.setConnectTimeout(20000)
                 .setSocketTimeout(20000).build();
 
@@ -96,7 +97,7 @@ public class Utils {
             }
         } finally {
             if (response != null) {
-                //使用后释放连接占用的资源
+                //Release the resources occupied by the connection after use
                 response.close();
             }
         }


### PR DESCRIPTION
您好，我在项目中使用macaca的java-sdk的时候发现 
进行对macacaserver请求（http）的时候会出现大量的卡在CLOSE_WAIT状态的socket，持续时间很长 
一段时间之后java进程就会出现持有句柄数过多的错误  网上查询资料认为是由于以下两个原因引起的 

1、macaca_server断开连接的代码似乎有问题，主动断开请求之后，不再进行后续的断开ack，导致客户端的socket状态卡在了CLOSE_WAIT 
2、java客户端未使用http连接池，所以没有对socket连接进行管理，自己close掉CLOSE_WAIT状态的socket  

所以我针对以上第二点进行了优化，使用PoolingHttpClientConnectionManager对http socket进行管理，经初步测试解决了CLOSE_WAIT导致连接句柄溢出的问题.(周末让应用程序跑了两天，没有再发现句柄泄露的问题)